### PR TITLE
add wp_enqueue_media() to ensure presence of all media js APIs

### DIFF
--- a/inc/ij-post-attachments.php
+++ b/inc/ij-post-attachments.php
@@ -104,6 +104,8 @@ class IJ_Post_Attachments
 		if ($hook_suffix != 'post.php')
 			return;
 
+		wp_enqueue_media();
+
 		wp_enqueue_script(
 			'ij-post-attachments', IJ_POST_ATTACHMENTS_URL . 'scripts/ij-post-attachments.js',
 			array('jquery-ui-sortable'), IJ_POST_ATTACHMENTS_VER


### PR DESCRIPTION
When there is not js wp media api enqueued in a custom post type, the plugin fail to open media library modal when the user click on "add media", with this little change, the plugin work also in this case